### PR TITLE
Role respawn

### DIFF
--- a/lua/damagelogs/client/rdm_manager.lua
+++ b/lua/damagelogs/client/rdm_manager.lua
@@ -856,6 +856,12 @@ net.Receive("DL_Death", function()
     end
 end)
 
+net.Receive("DL_Delayed", function()
+    if #Damagelog.ReportsQueue > 0 then
+        LocalPlayer():PrintMessage(HUD_PRINTTALK, string_format(TTTLogTranslate(GetDMGLogLang, "reportDelayed"), #Damagelog.ReportsQueue))
+    end
+end)
+
 net.Receive("DL_SendForgive", function()
     local previous = net.ReadUInt(1) == 1
     local canceled = net.ReadUInt(1) == 1

--- a/lua/damagelogs/server/rdm_manager.lua
+++ b/lua/damagelogs/server/rdm_manager.lua
@@ -680,6 +680,12 @@ hook_Add("PlayerInitialSpawn", "PlayerInitialSpawn_RDM_Manager", function(ply)
 end)
 
 hook_Add("PlayerDeath", "RDM_Manager", function(ply)
+
+    --Instant Respawn Cases
+    timer.Simple(1, function()
+        if ply:Alive() then return end
+    end)
+
     net.Start("DL_Death")
     net.Send(ply)
 end)

--- a/lua/damagelogs/server/rdm_manager.lua
+++ b/lua/damagelogs/server/rdm_manager.lua
@@ -697,11 +697,9 @@ hook_Add("PlayerDeath", "RDM_Manager", function(ply)
         end)
         -- Delayed Respawn Check
         if CheckRevive(ply) then
-            /*
-            if (reportcount > 0) then
-                ply:PrintMessage(HUD_PRINTTALK, "You have " .. reportcount .. " pending reports, you are required to respond if you are unable to be revived.")
-            end
-            */
+            net.Start("DL_Delayed")
+            net.Send(ply)
+
             timer.Create("RDM_RespawnDelay_" .. ply:SteamID64(), 5, 1, function()
                 net.Start("DL_Death")
                 net.Send(ply)

--- a/lua/damagelogs/shared/lang/english.lua
+++ b/lua/damagelogs/shared/lang/english.lua
@@ -413,5 +413,6 @@ DamagelogLang.english = {
 
     role_change = "%s [%s] has changed into [%s]",
     role_item = "%s [%s] used %s on %s [%s]",
-    revive = "%s [%s] has been revived"
+    revive = "%s [%s] has been revived",
+    reportDelayed = "You have %s pending reports against you, you are required to respond if you are unable to be revived shortly."
 }


### PR DESCRIPTION
added checks to prevent the report window from showing up if the player has a revive ability, or has been affected by an ability that causes instant revive from death